### PR TITLE
fix/postFiles

### DIFF
--- a/client/src/api/postFiles.ts
+++ b/client/src/api/postFiles.ts
@@ -1,16 +1,18 @@
-import {API_ROUTES} from "./client";
+import {API_ROUTES, euroMillionsFetch} from "./client";
 
-export const postFiles = async(files: File[]) => {
+export const postFiles = async (files: File[]) => {
 
 	const body = new FormData();
-	files.forEach(f => {body.append('file', f);});
+	files.forEach(f => {
+		body.append('file', f);
+	});
 
-	const httpResponse =await fetch(API_ROUTES.uploadFiles, {
+	const httpResponse = await euroMillionsFetch(API_ROUTES.uploadFiles, {
 		method: 'POST',
 		body: body,
 	})
 
-	if(!httpResponse.ok) {
+	if (!httpResponse.ok) {
 		throw new Error(`PostFiles failed with status ${httpResponse.status}`);
 	}
 

--- a/server/EuroMillions.API/Routes/DrawRoutes.cs
+++ b/server/EuroMillions.API/Routes/DrawRoutes.cs
@@ -29,7 +29,7 @@ public static class DrawRoutes
         );
 
         drawsGroup.MapPost(
-            "/historyfiles",
+            "/upload",
             async ([FromServices] DrawResources drawResources, [FromForm] IFormFileCollection files) =>
             await drawResources.UploadFilesAsync(files)
         );


### PR DESCRIPTION
- Replaced `fetch` with `euroMillionsFetch` in `postFiles` for consistency.
- Updated endpoint in `DrawRoutes.cs` from `/historyfiles` to `/upload` for clearer naming.